### PR TITLE
Allow using a list for `--cors-origin`

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,9 +22,12 @@ var (
 	zone               = flag.String("zone", "local", "Availability zone within which this process is running")
 )
 
+var corsConfig *corsSettings
+
 func main() {
 	flag.Parse()
 	envy.Parse("GATEWAY")
+	corsConfig = NewCorsSettings(*corsOrigin)
 
 	pb.RegisterGRPCDispatcher(*zone)
 


### PR DESCRIPTION
This will allow us to use more than one value in production, enabling both safe access from the production dashboard, as well as letting devs use the production gateway from their local machines.