### PR TITLE
add /healthz endpoint for health checks

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	context "context"
 	"flag"
 	"log"
+	"net/http"
 	"os"
 
 	"github.com/jamiealquiza/envy"
@@ -44,6 +45,10 @@ func main() {
 
 	pb.RegisterJournalServer(srv.GRPCServer, journalServer)
 	pc.RegisterShardServer(srv.GRPCServer, shardServer)
+
+	srv.HTTPMux.Handle("/healthz", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("OK\n"))
+	}))
 	srv.HTTPMux.Handle("/", restServer)
 
 	srv.QueueTasks(tasks)


### PR DESCRIPTION
Fixes #5

Tested locally:

	$ curl -v http://localhost:12345/healthz
	*   Trying 127.0.0.1:12345...
	* Connected to localhost (127.0.0.1) port 12345 (#0)
	> GET /healthz HTTP/1.1
	> Host: localhost:12345
	> User-Agent: curl/7.81.0
	> Accept: */*
	>
	* Mark bundle as not supporting multiuse
	< HTTP/1.1 200 OK
	< Date: Thu, 07 Jul 2022 16:30:25 GMT
	< Content-Length: 3
	< Content-Type: text/plain; charset=utf-8
	<
	OK
	* Connection #0 to host localhost left intact