### PR TITLE
Fix multiplexing of HTTP1, 2, and gRPC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ clean:
 
 .PHONY: test
 test:
-	deno test client/test/ --allow-net --allow-read --allow-write --unstable
+	deno test client/test/ --allow-net --allow-read --allow-write --unstable --unsafely-ignore-certificate-errors
 
 .PHONY: update_snapshots
 update_snapshots:

--- a/client/test/test_support.ts
+++ b/client/test/test_support.ts
@@ -1,6 +1,6 @@
 import * as jose from "https://deno.land/x/jose@v4.8.1/index.ts";
 
-export const BASE_URL = new URL("http://localhost:28318");
+export const BASE_URL = new URL("https://localhost:28318");
 
 const SIGNING_KEY = new TextEncoder().encode("supersecret");
 

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,12 @@ require (
 	github.com/gogo/gateway v1.1.0
 	github.com/golang-jwt/jwt/v4 v4.4.1
 	github.com/golang/protobuf v1.5.2
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/jamiealquiza/envy v1.1.0
-	github.com/soheilhy/cmux v0.1.5
 	github.com/urfave/negroni v1.0.0
 	go.gazette.dev/core v0.89.1-0.20220825171317-54b34a7d85ec
+	golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/grpc v1.45.0
 )
@@ -22,7 +23,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/uuid v1.3.0 // indirect
-	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/klauspost/compress v1.13.5 // indirect
@@ -36,8 +36,7 @@ require (
 	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/cobra v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
-	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
+	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20220317150908-0efb43f6373e // indirect
 	google.golang.org/protobuf v1.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -375,8 +375,6 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.0 h1:2aQv6F436YnN7I4VbI8PPYrBhu+SmrTaADcf8Mi/
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v3 v3.5.0 h1:62Eh0XOro+rDwkrypAGDfgmNh5Joq+z+W9HZdlXMzek=
 go.etcd.io/etcd/client/v3 v3.5.0/go.mod h1:AIKXXVX/DQXtfTEqBryiLTUXwON+GuvO6Z7lLS/oTh0=
-go.gazette.dev/core v0.89.1-0.20220422155930-55af5cf8cd88 h1:XgLLr+4Kmax40R3PdeLlNnwURVZQwqroWh8czWDMgGM=
-go.gazette.dev/core v0.89.1-0.20220422155930-55af5cf8cd88/go.mod h1:c/5g5752X3AH+g1ItiQaq9x+gmCFRmdTCFSkp5hypVQ=
 go.gazette.dev/core v0.89.1-0.20220825171317-54b34a7d85ec h1:L9XmQ5J2KihaLTQn5iWyum04bZOItr83j1BmmNJ2MKk=
 go.gazette.dev/core v0.89.1-0.20220825171317-54b34a7d85ec/go.mod h1:c/5g5752X3AH+g1ItiQaq9x+gmCFRmdTCFSkp5hypVQ=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
@@ -487,8 +485,8 @@ golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd h1:O7DYs+zxREGLKzKoMQrtrEacpb0ZVXA5rIwylE2Xchk=
-golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b h1:ZmngSVLe/wycRns9MKikG9OWIEjGcGAkacif7oYQaUY=
+golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -577,8 +575,8 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 h1:WIoqL4EROvwiPdUtaip4VcDdpZ4kha7wBWZrbVKCIZg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/journal_server.go
+++ b/journal_server.go
@@ -28,6 +28,7 @@ func NewJournalAuthServer(ctx context.Context) *JournalAuthServer {
 }
 
 func newJournalClient(ctx context.Context, addr string) (pb.JournalClient, error) {
+	log.Printf("connecting journal client to: %s", addr)
 	conn, err := dialAddress(ctx, addr)
 	if err != nil {
 		return nil, fmt.Errorf("error connecting to server: %w", err)

--- a/main.go
+++ b/main.go
@@ -9,12 +9,16 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/jamiealquiza/envy"
 	pb "go.gazette.dev/core/broker/protocol"
 	pc "go.gazette.dev/core/consumer/protocol"
-	"go.gazette.dev/core/server"
 	"go.gazette.dev/core/task"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+	"google.golang.org/grpc"
 )
 
 var (
@@ -64,32 +68,49 @@ func main() {
 			log.Fatalf("must supply --tls-certificate with --tls-private-key")
 		}
 	}
-
-	srv, err := server.NewFromListener(listener)
-	if err != nil {
-		log.Fatalf("failed to create server: %v", err)
-	}
+	var grpcServer = grpc.NewServer(
+		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
+		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
+	)
 
 	tasks := task.NewGroup(context.Background())
 	ctx := pb.WithDispatchDefault(tasks.Context())
+
 	journalServer := NewJournalAuthServer(ctx)
 	shardServer := NewShardAuthServer(ctx)
-	restServer := NewRestServer(ctx, srv.Endpoint().GRPCAddr())
+	pb.RegisterJournalServer(grpcServer, journalServer)
+	pc.RegisterShardServer(grpcServer, shardServer)
 
-	pb.RegisterJournalServer(srv.GRPCServer, journalServer)
-	pc.RegisterShardServer(srv.GRPCServer, shardServer)
+	httpMux := http.NewServeMux()
+	restHandler := NewRestServer(ctx, listener.Addr().String())
 
-	srv.HTTPMux.Handle("/healthz", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	httpMux.Handle("/healthz", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte("OK\n"))
 	}))
-	srv.HTTPMux.Handle("/", restServer)
+	httpMux.Handle("/", restHandler)
 
-	srv.QueueTasks(tasks)
-	tasks.GoRun()
+	// compose both http and grpc into a single handler, that dispatches each request based on
+	// the content-type. It's important that we do this on a per-request basis instead of a
+	// per-connection basis because this server may be behind a load balancer, which will maintain
+	// persistent connections that get re-used for both protocols. This approach was taken from:
+	// https://ahmet.im/blog/grpc-http-mux-go/
+	var mixedHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("content-type"), "application/grpc") {
+			grpcServer.ServeHTTP(w, r)
+		} else {
+			httpMux.ServeHTTP(w, r)
+		}
+	})
 
-	log.Printf("Listening on %s\n", srv.Endpoint().URL())
+	// Whether we're running with TLS or not, we need to use http2 in order for grpc to work.
+	// The `h2c.NewHandler` enables us to use http2 without tls.
+	var http2Server = http2.Server{}
+	var http1Server = &http.Server{Handler: h2c.NewHandler(mixedHandler, &http2Server)}
 
-	if err := tasks.Wait(); err != nil {
+	log.Printf("Listening on %s\n", listener.Addr().String())
+
+	err = http1Server.Serve(listener)
+	if err != nil {
 		log.Fatalf("Failed to serve: %v", err)
 	}
 

--- a/rest.go
+++ b/rest.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"log"
 	"net/http"
 	"regexp"
@@ -12,12 +13,22 @@ import (
 	"github.com/urfave/negroni"
 	_ "go.gazette.dev/core/broker/protocol"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
 	bgw "github.com/estuary/data-plane-gateway/gen/broker/protocol"
 	cgw "github.com/estuary/data-plane-gateway/gen/consumer/protocol"
 )
 
+// NewRestServer  returns an http.Handler that proxies REST requests to broker and consumer gRPC
+// services. The `gatewayAddr` parameter, surprisingly, is what it proxies _to_. It establishes a
+// connection to `gatewayAddr` immediately, because grpc-gateway requires an established connection
+// before it can register the handlers. There's no good reason for that. It's just how it do. So
+// because grpc-gateway requires an established connection, we proxy to _ourselves_ instead of the
+// actual broker and consumer endpoints, so that we are able to start this thing even when the
+// broker or consumer are unavailable. If you know of a way to avoid this nonsense and lazily
+// connect to the broker/consumer endpoints, then please feel free to implement that and delete this
+// nauseating comment.
 func NewRestServer(ctx context.Context, gatewayAddr string) http.Handler {
 	var err error
 
@@ -31,7 +42,18 @@ func NewRestServer(ctx context.Context, gatewayAddr string) http.Handler {
 		runtime.WithProtoErrorHandler(runtime.DefaultHTTPProtoErrorHandler),
 	)
 
-	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	var creds credentials.TransportCredentials
+	if *tls_cert == "" {
+		creds = insecure.NewCredentials()
+	} else {
+		// If we're using a self-signed cert, then we need to skip verification.
+		// The cert _could_ be legit, but we don't really care, since we're only connecting on
+		// localhost anyway.
+		creds = credentials.NewTLS(&tls.Config{
+			InsecureSkipVerify: true,
+		})
+	}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(creds)}
 
 	err = bgw.RegisterJournalHandlerFromEndpoint(ctx, mux, gatewayAddr, opts)
 	if err != nil {

--- a/shard_server.go
+++ b/shard_server.go
@@ -28,6 +28,7 @@ func NewShardAuthServer(ctx context.Context) *ShardAuthServer {
 }
 
 func newShardClient(ctx context.Context, addr string) (pc.ShardClient, error) {
+	log.Printf("connecting shard client to: %s", addr)
 	conn, err := dialAddress(ctx, addr)
 	if err != nil {
 		return nil, fmt.Errorf("error connecting to server: %w", err)


### PR DESCRIPTION
Multiplexing of these protocols was broken in a few ways. One was that
REST requests that were sent over HTTP2 were never handled due to not
matching any CMux handler. Another issue was that load balancers would
maintain persistent connections to the server which would be re-used for
both REST and gRPC calls. This was incompatible with CMux, which
determines the handler for a given connection only once, when the
connection is established.

This commit implements the approach described in:
https://ahmet.im/blog/grpc-http-mux-go/
It invokes either the grpc or http handler for each request, based on
the Content-Type header.

Additionally, the tests were modified to use TLS with a self-signed
certificate in order to more closely mimic real-world usage.