### PR TITLE
set Path attribute in auth cookie to fix proxy auth in chrome

### DIFF
--- a/proxy/redirect.go
+++ b/proxy/redirect.go
@@ -61,6 +61,7 @@ func (h *authRedirectHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 		Value:    token,
 		Secure:   true,
 		HttpOnly: true,
+		Path:     "/",
 	}
 	http.SetCookie(w, cookie)
 	http.Redirect(w, req, origUrl, 307)


### PR DESCRIPTION
Authentication for private ports was broken in Chrome, and perhaps other browsers too.  This was caused by the browser rejecting the `__Host-flow_auth` cookie that was attempted to be set by data-plane-gateway.  The browser was rejecting the cookie for a seemingly legitimate reason: the spec says it has to be there.  I suspect that Firefox was more lax in this case because `Path=/` is semantically equivalent to it not being set at all.  In any case, adding the `Path=/` allows authenticated access to private ports to work properly in both Chrome and Firefox.


Fixes estuary/connectors#695