### PR TITLE
enable self-service ops collections via special case

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build Stage
 ################################################################################
-FROM golang:1.19-buster as builder
+FROM golang as builder
 
 WORKDIR /builder
 
@@ -30,7 +30,7 @@ FROM busybox:1.34-musl as busybox
 
 # Runtime Stage
 ################################################################################
-FROM gcr.io/distroless/base-debian10
+FROM gcr.io/distroless/base-debian11
 
 COPY --from=busybox /bin/sh /bin/sh
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/estuary/data-plane-gateway
 
-go 1.19
+go 1.21
 
 require (
 	github.com/estuary/flow v0.1.9-0.20230303181027-f65a9d7f1a89


### PR DESCRIPTION
This is a medium-term ... hack, which enables users to read the ops logs and stats of their own tasks. When reading the especially-enumerated collections, we bypass traditional prefix authorization and instead authorize over the `name` partition of the logs or stats collection.

Testing:
 * Verified this enables the new ops view of the entity details page.
 * Verified that slightly perturbing how build up allowed prefixes causes unauthorized errors to be returned.
 * Verified that a locally-modified `flowctl` is able to list journals and fragments of task logs, as well as read them, as a regular user of a local stack.