### PR TITLE
upgrade to go 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/estuary/data-plane-gateway
 
-go 1.21
+go 1.22
 
 require (
 	github.com/estuary/flow v0.1.9-0.20230303181027-f65a9d7f1a89


### PR DESCRIPTION
We're hoping that this will help address the high CPU usage we've observed in production when there's a lot of new connections being created. See: https://github.com/golang/go/issues/63516#issuecomment-1887886804