### PR TITLE
fully specify go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/estuary/data-plane-gateway
 
-go 1.22
+go 1.22.2
 
 require (
 	github.com/estuary/flow v0.1.9-0.20230303181027-f65a9d7f1a89


### PR DESCRIPTION
See: https://github.com/golang/go/issues/62278#issuecomment-1693538776 I have no idea why this was working in CI.